### PR TITLE
Fix fatal performance issue with Dispatch function

### DIFF
--- a/AnalyticalShadows/Assets/AnalyticalShadows/AnalyticalShadowsRenderer.cs
+++ b/AnalyticalShadows/Assets/AnalyticalShadows/AnalyticalShadowsRenderer.cs
@@ -375,7 +375,7 @@ namespace AnalyticalShadows
             context.command.SetComputeTextureParam(computeShader, compute_main, "WorldPosition", worldPosition);
             context.command.SetComputeTextureParam(computeShader, compute_main, "MaskBuffer", maskBuffer);
             context.command.SetComputeTextureParam(computeShader, compute_main, "Result", computeWrite);
-            context.command.DispatchCompute(computeShader, compute_main, resolutionX, resolutionY, 1);
+            context.command.DispatchCompute(computeShader, compute_main, Mathf.CeilToInt(resolutionX / 8f), Mathf.CeilToInt(resolutionY / 8f), 1);
 
             if(settings.useBilaterialBlur.value)
             {


### PR DESCRIPTION
As described in this tutorial: https://catlikecoding.com/unity/tutorials/basics/compute-shaders/
Number of thread groups provided needs to be `Mathf.CeilToInt(resolutionX / numthreads(x))`

As the numthreads is (8, 8, 1) in compute shader, we have to divide resolution by 8.

So right now, if we have resolution of 1280, it tells GPU to process 1280 8x8 groups of pixels, instead of needed 160.
And thus it was processing 7 times more non-existing groups, that were writing into nothing, and killing all performance.

With this fix, FPS (on GT 740m) in sample scene instead from 1~2, to 26-33!